### PR TITLE
Fix blank frames in scrolling display

### DIFF
--- a/ui/v1/displayscreen/model.go
+++ b/ui/v1/displayscreen/model.go
@@ -43,4 +43,5 @@ func (m *Model) SetSize(width, height int) {
 
 func (m *Model) SetDisplay(s string) {
 	m.display = s
+	m.scrollOffset = 0
 }

--- a/ui/v1/displayscreen/update.go
+++ b/ui/v1/displayscreen/update.go
@@ -9,6 +9,8 @@ import (
 	"github.com/dubeyKartikay/lazyspotify/ui/v1/common"
 )
 
+const scrollGap = "   "
+
 func (m *Model) SetDisplayFromSong(song common.SongInfo) {
 	if song.Title == "" {
 		return
@@ -19,6 +21,7 @@ func (m *Model) SetDisplayFromSong(song common.SongInfo) {
 		m.styles.muted.Render(song.Artist) +
 		m.styles.accent.Render(separator) +
 		m.styles.muted.Render(song.Album)
+	m.scrollOffset = 0
 }
 
 func (m *Model) Update(tea.Msg) tea.Cmd {
@@ -26,8 +29,8 @@ func (m *Model) Update(tea.Msg) tea.Cmd {
 }
 
 func (m *Model) NextFrame() tea.Cmd {
-	if len(m.display) > 0 {
-		m.scrollOffset = (m.scrollOffset + 1) % len(m.display)
+	if span := m.scrollSpan(m.display); span > 0 {
+		m.scrollOffset = (m.scrollOffset + 1) % span
 	}
 	return ticker.DoTick()
 }
@@ -36,22 +39,24 @@ func (m *Model) scrollText(text string, width int) string {
 	if width <= 0 {
 		return ""
 	}
-	if lipglossWidth(text) <= width {
+	if ansi.StringWidth(text) <= width {
 		return text
 	}
 
-	const gap = "   "
-	base := text + gap
+	base := text + scrollGap
 	track := base + base
-	if len(base) == 0 {
+	span := m.scrollSpan(text)
+	if span == 0 {
 		return strings.Repeat(" ", width)
 	}
 
-	start := m.scrollOffset
-	end := min(len(track), start+width)
-	return ansi.Cut(track, start, end)
+	start := m.scrollOffset % span
+	return ansi.Cut(track, start, start+width)
 }
 
-func lipglossWidth(text string) int {
-	return len([]rune(ansi.Strip(text)))
+func (m *Model) scrollSpan(text string) int {
+	if text == "" {
+		return 0
+	}
+	return ansi.StringWidth(text + scrollGap)
 }

--- a/ui/v1/displayscreen/update_test.go
+++ b/ui/v1/displayscreen/update_test.go
@@ -1,0 +1,31 @@
+package displayscreen
+
+import (
+	"testing"
+
+	ansi "github.com/charmbracelet/x/ansi"
+	"github.com/dubeyKartikay/lazyspotify/ui/v1/common"
+)
+
+func TestScrollTextDoesNotGoBlankAcrossTicks(t *testing.T) {
+	m := NewModel()
+	m.SetDisplayFromSong(common.SongInfo{
+		Title:  "A Very Long Track Title",
+		Artist: "A Verbose Artist",
+		Album:  "An Even Longer Album Name",
+	})
+
+	const width = 12
+	frames := len(m.display) * 2
+	if frames == 0 {
+		t.Fatal("expected non-empty display")
+	}
+
+	for i := 0; i < frames; i++ {
+		frame := m.scrollText(m.display, width)
+		if ansi.StringWidth(frame) == 0 {
+			t.Fatalf("blank frame at tick %d with offset %d", i, m.scrollOffset)
+		}
+		m.NextFrame()
+	}
+}


### PR DESCRIPTION
## Summary
- Reset scroll position whenever the display text changes so new content starts from the beginning.
- Use a width-aware scroll span instead of raw string length to keep scrolling aligned with rendered text.
- Add a regression test that verifies scrolling never renders a blank frame across multiple ticks.

## Testing
- `go test ./ui/v1/displayscreen`
- Not run: full repository test suite