### PR TITLE
Fix player button press handling by kind

### DIFF
--- a/ui/v1/player/model.go
+++ b/ui/v1/player/model.go
@@ -52,12 +52,12 @@ func NewModel() Model {
 
 func newButtons() []button {
 	specs := []buttonSpec{
+		{kind: PreviousButton, icon: "|<"},
+		{kind: SeekBackwardButton, icon: "<<"},
 		{kind: PlayButton, icon: "|>"},
 		{kind: PauseButton, icon: "||"},
 		{kind: SeekForwardButton, icon: ">>"},
-		{kind: SeekBackwardButton, icon: "<<"},
 		{kind: NextButton, icon: ">|"},
-		{kind: PreviousButton, icon: "|<"},
 	}
 	return buildButtons(specs)
 }

--- a/ui/v1/player/model_test.go
+++ b/ui/v1/player/model_test.go
@@ -1,0 +1,46 @@
+package player
+
+import "testing"
+
+func TestNewButtonsOrder(t *testing.T) {
+	buttons := newButtons()
+
+	got := make([]ButtonKind, 0, len(buttons))
+	for _, button := range buttons {
+		got = append(got, button.kind)
+	}
+
+	want := []ButtonKind{
+		PreviousButton,
+		SeekBackwardButton,
+		PlayButton,
+		PauseButton,
+		SeekForwardButton,
+		NextButton,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("button count = %d, want %d", len(got), len(want))
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("button[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestHandleButtonPressFindsButtonByKind(t *testing.T) {
+	model := NewModel()
+
+	model.HandleButtonPress(NextButton)
+
+	for _, button := range model.controls {
+		if button.kind == NextButton && !button.pressed {
+			t.Fatal("expected next button to be pressed")
+		}
+		if button.kind != NextButton && button.pressed {
+			t.Fatalf("button %v unexpectedly pressed", button.kind)
+		}
+	}
+}

--- a/ui/v1/player/update.go
+++ b/ui/v1/player/update.go
@@ -24,11 +24,14 @@ func (m *Model) NextButtonFrame() {
 }
 
 func (m *Model) HandleButtonPress(kind ButtonKind) tea.Cmd {
-	if int(kind) < 0 || int(kind) >= len(m.controls) {
-		return nil
+	for idx := range m.controls {
+		if m.controls[idx].kind != kind {
+			continue
+		}
+		m.controls[idx].pressed = true
+		return ticker.DoTickClick()
 	}
-	m.controls[kind].pressed = true
-	return ticker.DoTickClick()
+	return nil
 }
 
 func (m *Model) UpdateStatus(status Status) {


### PR DESCRIPTION
## Summary
- Reordered the player button definitions so the control layout matches the intended button kinds.
- Updated button press handling to select controls by `ButtonKind` instead of slice index.
- Added tests covering button ordering and verifying the pressed state is applied to the matching button kind.

## Testing
- Not run
- Added unit coverage in `ui/v1/player/model_test.go` for `newButtons()` ordering
- Added unit coverage in `ui/v1/player/model_test.go` for `HandleButtonPress(NextButton)` selecting the correct control