### PR TITLE
Package librespot daemon and tighten auth/runtime behavior

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kartikay Dubey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,115 @@
+# lazyspotify
+
+`lazyspotify` is a terminal Spotify client that uses a patched `go-librespot`
+daemon for playback.
+
+## Runtime requirements
+
+- A Spotify Premium account.
+- A patched `go-librespot` daemon build from
+  `https://github.com/dubeyKartikay/go-librespot/`.
+- A working system keyring.
+  On Linux this is a hard requirement: `lazyspotify` will not fall back to
+  plaintext token storage if the keyring is unavailable.
+- Linux clipboard integration is optional.
+  For the auth screen's copy shortcut, install one of `wl-clipboard`, `xclip`,
+  or `xsel`.
+
+## Daemon discovery
+
+At startup, `lazyspotify` resolves the playback daemon in this order:
+
+1. `librespot.daemon.cmd` from `config.yaml`
+2. A packaged default daemon path compiled into the binary at build time
+
+Not supported:
+
+- `LAZYSPOTIFY_LIBRESPOT_DAEMON`
+- `PATH` lookup
+- probing next to the executable
+- relocatable bundled daemon discovery
+
+If you install `lazyspotify` without packaging and do not compile in a default
+daemon path, you must set `librespot.daemon.cmd`.
+
+## Installation
+
+### Packaged install
+
+When you package `lazyspotify`, ship both binaries together and compile the
+daemon path into the `lazyspotify` binary:
+
+- `lazyspotify`
+- `lazyspotify-librespot`
+
+Linux packages should install the daemon at:
+
+```text
+/usr/libexec/lazyspotify/lazyspotify-librespot
+```
+
+Build `lazyspotify` for Linux packages with:
+
+```bash
+go build -ldflags "-X github.com/dubeyKartikay/lazyspotify/core/utils.defaultLibrespotDaemonPath=/usr/libexec/lazyspotify/lazyspotify-librespot" -o target/lazyspotify ./cmd/lazyspotify/main.go
+```
+
+For Homebrew on macOS, install the daemon under the formula's `opt_libexec`
+path and inject that stable absolute path with `-ldflags -X` during the build.
+
+### Source build
+
+Build `lazyspotify`:
+
+```bash
+go build -o target/lazyspotify ./cmd/lazyspotify/main.go
+```
+
+Build the patched daemon from the forked `go-librespot` repository and set an
+explicit config override:
+
+```yaml
+librespot:
+  daemon:
+    cmd:
+      - /absolute/path/to/lazyspotify-librespot
+```
+
+## Configuration
+
+Config lives under the OS config directory:
+
+- macOS: `~/Library/Application Support/lazyspotify/config.yaml`
+- Linux: `~/.config/lazyspotify/config.yaml`
+
+Only overrides are required. Package builds may provide a compiled default
+daemon path.
+
+Example:
+
+```yaml
+librespot:
+  daemon:
+    cmd:
+      - /absolute/path/to/lazyspotify-librespot
+```
+
+## Development
+
+Run the app:
+
+```bash
+make run
+```
+
+Build the app:
+
+```bash
+make build
+```
+
+Run tests:
+
+```bash
+go test ./...
+```

--- a/core/auth/keyring.go
+++ b/core/auth/keyring.go
@@ -2,13 +2,15 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"runtime"
 
 	"github.com/dubeyKartikay/lazyspotify/core/logger"
 	"github.com/dubeyKartikay/lazyspotify/core/utils"
 	"github.com/zalando/go-keyring"
 	"golang.org/x/oauth2"
 )
-
 
 type Keyring struct {
 	service string
@@ -19,31 +21,50 @@ func NewSpotifyKeyring() *Keyring {
 }
 
 func (k *Keyring) GetString(key string) (string, error) {
-  return keyring.Get(k.service, key)
+	value, err := keyring.Get(k.service, key)
+	if err != nil {
+		return "", wrapKeyringError(err)
+	}
+	return value, nil
 }
 
 func (k *Keyring) SetString(key, value string) error {
-	return keyring.Set(k.service, key, value)
+	return wrapKeyringError(keyring.Set(k.service, key, value))
 }
 
 func (k *Keyring) GetToken(key string) (*oauth2.Token, error) {
 	savedToken := oauth2.Token{}
-  ser_token, err := k.GetString(key)
-	if(err != nil) {
-    return nil, err
-  }
-  err = json.Unmarshal([]byte(ser_token), &savedToken)
-	if (err != nil){
-		return nil , err
+	ser_token, err := k.GetString(key)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(ser_token), &savedToken)
+	if err != nil {
+		return nil, err
 	}
 	return &savedToken, nil
 }
 
 func (k *Keyring) SetToken(key string, token *oauth2.Token) error {
-  ser_token, err := json.Marshal(token)
-  if (err != nil){
-    logger.Log.Error().Err(err).Msg("error marshaling token")
-    return err
-  }
-  return k.SetString(key, string(ser_token))
+	ser_token, err := json.Marshal(token)
+	if err != nil {
+		logger.Log.Error().Err(err).Msg("error marshaling token")
+		return err
+	}
+	return k.SetString(key, string(ser_token))
+}
+
+func wrapKeyringError(err error) error {
+	if err == nil || errors.Is(err, keyring.ErrNotFound) {
+		return err
+	}
+
+	if runtime.GOOS == "linux" {
+		return fmt.Errorf(
+			"system keyring unavailable: %w; lazyspotify requires a working Linux keyring and will not fall back to plaintext token storage",
+			err,
+		)
+	}
+
+	return fmt.Errorf("system keyring unavailable: %w", err)
 }

--- a/core/utils/app_config.go
+++ b/core/utils/app_config.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
@@ -63,21 +64,22 @@ func getDefaultAppConfig() AppConfig {
 	cfg.Librespot.MaxRetries = 3
 	cfg.Librespot.SeekStepMs = 5000
 	cfg.Librespot.VolumeStep = 65535 / 20
-	cfg.Librespot.Daemon.Cmd = []string{"/Users/user/personal/lazyspotify/.context/go-librespot/daemon"}
 	return cfg
 }
 
 func LoadConfig() (AppConfig, error) {
 	v := viper.New()
+	applyConfigDefaults(v)
 	v.SetConfigName("config")
 	v.SetConfigType("yaml")
 	v.AddConfigPath(SafeGetConfigDir())
 	err := v.ReadInConfig()
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	v.AutomaticEnv()
-	if err != nil {
+	var configErr viper.ConfigFileNotFoundError
+	if err != nil && !errors.As(err, &configErr) {
 		return AppConfig{}, err
 	}
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	v.AutomaticEnv()
 	var config AppConfig
 	err = v.Unmarshal(&config)
 	if err != nil {
@@ -99,4 +101,22 @@ func SafeGetConfigDir() string {
 	configDir := getConfigDir()
 	EnsureExists(configDir)
 	return configDir
+}
+
+func applyConfigDefaults(v *viper.Viper) {
+	defaults := getDefaultAppConfig()
+	v.SetDefault("auth.host", defaults.Auth.Host)
+	v.SetDefault("auth.port", defaults.Auth.Port)
+	v.SetDefault("auth.redirect-endpoint", defaults.Auth.RedirectEndpoint)
+	v.SetDefault("auth.timeout", defaults.Auth.Timeout)
+	v.SetDefault("auth.keyring.service", defaults.Auth.Keyring.Service)
+	v.SetDefault("auth.keyring.key", defaults.Auth.Keyring.Key)
+	v.SetDefault("librespot.host", defaults.Librespot.Host)
+	v.SetDefault("librespot.port", defaults.Librespot.Port)
+	v.SetDefault("librespot.timeout", defaults.Librespot.Timeout)
+	v.SetDefault("librespot.retry-delay", defaults.Librespot.RetryDelay)
+	v.SetDefault("librespot.max-retries", defaults.Librespot.MaxRetries)
+	v.SetDefault("librespot.seek-step-ms", defaults.Librespot.SeekStepMs)
+	v.SetDefault("librespot.volume-step", defaults.Librespot.VolumeStep)
+	v.SetDefault("librespot.daemon.zeroconf_enabled", defaults.Librespot.Daemon.ZeroconfEnabled)
 }

--- a/core/utils/clipboard.go
+++ b/core/utils/clipboard.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type clipboardCommand struct {
+	name string
+	args []string
+}
+
+var clipboardCommands = []clipboardCommand{
+	{name: "pbcopy"},
+	{name: "wl-copy"},
+	{name: "xclip", args: []string{"-selection", "clipboard"}},
+	{name: "xsel", args: []string{"--clipboard", "--input"}},
+}
+
+func CopyToClipboard(text string) error {
+	for _, clipboardCmd := range clipboardCommands {
+		path, err := exec.LookPath(clipboardCmd.name)
+		if err != nil {
+			continue
+		}
+
+		cmd := exec.Command(path, clipboardCmd.args...)
+		cmd.Stdin = strings.NewReader(text)
+		if err := cmd.Run(); err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no supported clipboard command found")
+}

--- a/core/utils/librespot_daemon.go
+++ b/core/utils/librespot_daemon.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+var defaultLibrespotDaemonPath = ""
+
+func ResolveLibrespotDaemonCmd(configured []string) ([]string, error) {
+	if len(configured) > 0 {
+		return configured, nil
+	}
+
+	if defaultLibrespotDaemonPath == "" {
+		return nil, fmt.Errorf(
+			"librespot daemon path is not configured: no packaged default was compiled in; set librespot.daemon.cmd in config or build with -ldflags \"-X github.com/dubeyKartikay/lazyspotify/core/utils.defaultLibrespotDaemonPath=...\"",
+		)
+	}
+
+	if err := validateDaemonExecutable(defaultLibrespotDaemonPath); err != nil {
+		return nil, fmt.Errorf(
+			"librespot daemon not available at packaged default %q: %w; install lazyspotify-librespot there or set librespot.daemon.cmd in config",
+			defaultLibrespotDaemonPath,
+			err,
+		)
+	}
+
+	return []string{defaultLibrespotDaemonPath}, nil
+}
+
+func validateDaemonExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("path is a directory")
+	}
+	if info.Mode()&0o111 == 0 {
+		return fmt.Errorf("path is not executable")
+	}
+	return nil
+}

--- a/core/utils/librespot_daemon_test.go
+++ b/core/utils/librespot_daemon_test.go
@@ -1,0 +1,116 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveLibrespotDaemonCmd_ConfigOverrideWins(t *testing.T) {
+	prev := defaultLibrespotDaemonPath
+	defaultLibrespotDaemonPath = ""
+	t.Cleanup(func() {
+		defaultLibrespotDaemonPath = prev
+	})
+
+	configured := []string{"/custom/librespot", "--flag"}
+	got, err := ResolveLibrespotDaemonCmd(configured)
+	if err != nil {
+		t.Fatalf("ResolveLibrespotDaemonCmd returned error: %v", err)
+	}
+	if len(got) != len(configured) {
+		t.Fatalf("got %d args, want %d", len(got), len(configured))
+	}
+	for i := range configured {
+		if got[i] != configured[i] {
+			t.Fatalf("got arg %d = %q, want %q", i, got[i], configured[i])
+		}
+	}
+}
+
+func TestResolveLibrespotDaemonCmd_UsesCompiledDefault(t *testing.T) {
+	path := makeExecutable(t)
+
+	prev := defaultLibrespotDaemonPath
+	defaultLibrespotDaemonPath = path
+	t.Cleanup(func() {
+		defaultLibrespotDaemonPath = prev
+	})
+
+	got, err := ResolveLibrespotDaemonCmd(nil)
+	if err != nil {
+		t.Fatalf("ResolveLibrespotDaemonCmd returned error: %v", err)
+	}
+	if len(got) != 1 || got[0] != path {
+		t.Fatalf("got %v, want [%q]", got, path)
+	}
+}
+
+func TestResolveLibrespotDaemonCmd_EmptyCompiledDefaultFails(t *testing.T) {
+	prev := defaultLibrespotDaemonPath
+	defaultLibrespotDaemonPath = ""
+	t.Cleanup(func() {
+		defaultLibrespotDaemonPath = prev
+	})
+
+	_, err := ResolveLibrespotDaemonCmd(nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no packaged default was compiled in") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "librespot.daemon.cmd") {
+		t.Fatalf("expected config guidance in error: %v", err)
+	}
+}
+
+func TestResolveLibrespotDaemonCmd_MissingCompiledDefaultFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing-librespot")
+
+	prev := defaultLibrespotDaemonPath
+	defaultLibrespotDaemonPath = path
+	t.Cleanup(func() {
+		defaultLibrespotDaemonPath = prev
+	})
+
+	_, err := ResolveLibrespotDaemonCmd(nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected path in error, got: %v", err)
+	}
+}
+
+func TestResolveLibrespotDaemonCmd_NonExecutableCompiledDefaultFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "librespot")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	prev := defaultLibrespotDaemonPath
+	defaultLibrespotDaemonPath = path
+	t.Cleanup(func() {
+		defaultLibrespotDaemonPath = prev
+	})
+
+	_, err := ResolveLibrespotDaemonCmd(nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not executable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func makeExecutable(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "librespot")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	return path
+}

--- a/librespot/librespot.go
+++ b/librespot/librespot.go
@@ -20,9 +20,12 @@ type Librespot struct {
 
 func InitLibrespot(ctx context.Context, userId string, accessToken string, panicOnDaemonFailure bool) (*Librespot, error) {
 	cfg := utils.GetConfig().Librespot
-	librespotCommand := cfg.Daemon.Cmd
-	librespotCommand = append(librespotCommand, "--config_dir", GetLibrespotConfigDir())
-	err := InitLibrespotConfig(ctx, userId, accessToken)
+	librespotCommand, err := utils.ResolveLibrespotDaemonCmd(cfg.Daemon.Cmd)
+	if err != nil {
+		return nil, err
+	}
+	librespotCommand = append(append([]string{}, librespotCommand...), "--config_dir", GetLibrespotConfigDir())
+	err = InitLibrespotConfig(ctx, userId, accessToken)
 	if err != nil {
 		return nil, err
 	}

--- a/ui/v1/auth/update.go
+++ b/ui/v1/auth/update.go
@@ -2,12 +2,11 @@ package auth
 
 import (
 	"context"
-	"os/exec"
-	"strings"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	coreauth "github.com/dubeyKartikay/lazyspotify/core/auth"
+	"github.com/dubeyKartikay/lazyspotify/core/utils"
 )
 
 var keyMap = struct {
@@ -46,9 +45,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		if key.Matches(msg, keyMap.CopyURL) && m.auth.AuthServer.Started.Load() {
 			url := m.auth.GetAuthURL()
-			cmd := exec.Command("pbcopy")
-			cmd.Stdin = strings.NewReader(url)
-			m.copied = cmd.Run() == nil
+			m.copied = utils.CopyToClipboard(url) == nil
 		}
 	case coreauth.AuthServerErr:
 		m.err = msg.Err


### PR DESCRIPTION
## Summary
- Add packaged-daemon discovery for `librespot`, with config override support and explicit failure when no valid daemon path is available.
- Harden auth token storage by surfacing keyring failures clearly and requiring a working Linux keyring instead of falling back to plaintext storage.
- Add clipboard helper support for auth URL copy across `pbcopy`, `wl-copy`, `xclip`, and `xsel`.
- Refresh project docs with packaging, runtime, and configuration guidance, and add an MIT license.

## Testing
- `go test ./...`
- Added unit coverage for daemon resolution behavior in `core/utils/librespot_daemon_test.go`.
- Not run: end-to-end packaging/build verification for the bundled daemon path and platform-specific clipboard commands.