### PR TITLE
Add release packaging and automated distribution publishing

### DIFF
--- a/packaging/release-manifest.yaml
+++ b/packaging/release-manifest.yaml
@@ -2,6 +2,6 @@
 # publish source bundles when the daemon is pinned only by commit.
 lazyspotify_version: "0.1.0"
 daemon_repo: "https://github.com/dubeyKartikay/go-librespot.git"
-daemon_tag: ""
+daemon_tag: "v0.7.1.1"
 daemon_commit: "4292571a38a1bca4ba1a92a334bc907c6c0a3549"
 bundle_version: "1"


### PR DESCRIPTION
## Summary
- Adds release packaging for Debian, RPM, macOS archives, Arch tarballs, AUR metadata, and Homebrew formulas.
- Introduces release automation workflows that build artifacts from tags, gate optional publish steps on detected secrets, and draft/publish GitHub Releases.
- Adds build metadata support via `buildinfo`, including `version`, `commit`, `build_date`, and `packaged_daemon_path`, and wires packaged daemon resolution through it.
- Updates docs and install guidance for the new distribution channels and package layouts.
- Pins the bundled daemon tag to `v0.7.1.1` and refreshes packaging-related project files.

## Testing
- Not run.
- Added/updated Go tests for build metadata and packaged daemon resolution.
- Added workflow and packaging scripts, but no end-to-end release pipeline execution was performed locally.