### PR TITLE
Require Spotify client ID at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,30 @@ Config lives under the OS config directory:
 Only overrides are required. Package builds may provide a compiled default
 daemon path.
 
+### Set Your Spotify Client ID
+
+`lazyspotify` now requires your own Spotify app client ID. Spotify does not
+allow individual apps to use extended quota for other users, so the bundled
+client ID has been removed.
+
+Set `auth.client_id` in `config.yaml`:
+
+```yaml
+auth:
+  client_id: your_spotify_app_client_id
+```
+
+Environment override:
+
+```bash
+export AUTH_CLIENT_ID=your_spotify_app_client_id
+```
+
 Example:
 
 ```yaml
+auth:
+  client_id: your_spotify_app_client_id
 librespot:
   daemon:
     cmd:

--- a/cmd/lazyspotify/main.go
+++ b/cmd/lazyspotify/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/dubeyKartikay/lazyspotify/buildinfo"
 	"github.com/dubeyKartikay/lazyspotify/cli"
+	"github.com/dubeyKartikay/lazyspotify/core/utils"
 	ui "github.com/dubeyKartikay/lazyspotify/ui/v1"
 )
 
@@ -20,6 +22,14 @@ func main() {
 	if versionFlag {
 		_ = buildinfo.PrintVersion(os.Stdout)
 		return
+	}
+	if flag.NArg() > 0 && flag.Arg(0) == "version" {
+		cli.Run(flag.Args())
+		return
+	}
+	if err := utils.ValidateStartupConfig(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 
 	switch {

--- a/core/auth/auth_config.go
+++ b/core/auth/auth_config.go
@@ -4,38 +4,42 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+
+	"github.com/dubeyKartikay/lazyspotify/core/utils"
 )
 
 type AuthConfig struct {
-	codeVerifier string;
-	codeChallenge string;
-	state string;
+	codeVerifier  string
+	codeChallenge string
+	state         string
+	clientID      string
 }
-
 
 func generateRandomString(length int) string {
 	b := make([]byte, length)
-	_,err := rand.Read(b)
+	_, err := rand.Read(b)
 	if err != nil {
 		panic("rand.Read failed")
 	}
-  return base64.RawURLEncoding.EncodeToString(b)
+	return base64.RawURLEncoding.EncodeToString(b)
 }
 
 func generateCodeChallenge(codeVerifier string) string {
 	h := sha256.New()
-  h.Write([]byte(codeVerifier))
-  return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+	h.Write([]byte(codeVerifier))
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
 }
 
 func NewAuthConfig() *AuthConfig {
 	codeVerifier := generateRandomString(32)
 	state := generateRandomString(32)
-  codeChallenge := generateCodeChallenge(codeVerifier)
+	codeChallenge := generateCodeChallenge(codeVerifier)
+	clientID := utils.GetConfig().SpotifyClientID()
 
-  return &AuthConfig{
-    codeVerifier: codeVerifier,
-    codeChallenge: codeChallenge,
-    state: state,
-  }
+	return &AuthConfig{
+		codeVerifier:  codeVerifier,
+		codeChallenge: codeChallenge,
+		state:         state,
+		clientID:      clientID,
+	}
 }

--- a/core/auth/auth_service.go
+++ b/core/auth/auth_service.go
@@ -29,7 +29,7 @@ func NewAuthService(redirectURI string) *AuthService {
 			"user-library-read",
 			"user-read-private",
 		),
-		spotifyauth.WithClientID("565c1a413de9452da373f1ed3aa6afbe"),
+		spotifyauth.WithClientID(authConfig.clientID),
 	)
 	return &AuthService{
 		sptAuth:    sptAuth,
@@ -42,7 +42,7 @@ func (a *AuthService) GetAuthURL() string {
 	return a.sptAuth.AuthURL(a.authConfig.state,
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
 		oauth2.SetAuthURLParam("code_challenge", a.authConfig.codeChallenge),
-		oauth2.SetAuthURLParam("client_id", "565c1a413de9452da373f1ed3aa6afbe"),
+		oauth2.SetAuthURLParam("client_id", a.authConfig.clientID),
 	)
 }
 

--- a/core/utils/app_config.go
+++ b/core/utils/app_config.go
@@ -2,29 +2,34 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"github.com/spf13/viper"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
-var config AppConfig
+const SpotifyClientIDHelpURL = "https://github.com/dubeyKartikay/lazyspotify#set-your-spotify-client-id"
+
+var (
+	config        AppConfig
+	configLoadErr error
+)
 
 func GetConfig() AppConfig {
 	return config
 }
 
 func init() {
-	var err error
-	config, err = LoadConfig()
-	if err != nil {
+	config, configLoadErr = LoadConfig()
+	if configLoadErr != nil {
 		config = getDefaultAppConfig()
 	}
 }
 
 type AppConfig struct {
-	SpotifyClientId string `mapstructure:"spotify-client-id"`
-	Auth            struct {
+	Auth struct {
+		ClientID         string `mapstructure:"client_id"`
 		Host             string `mapstructure:"host"`
 		Port             int    `mapstructure:"port"`
 		RedirectEndpoint string `mapstructure:"redirect-endpoint"`
@@ -47,6 +52,10 @@ type AppConfig struct {
 			ZeroconfEnabled bool     `mapstructure:"zeroconf_enabled"`
 		} `mapstructure:"daemon"`
 	} `mapstructure:"librespot"`
+}
+
+func (c AppConfig) SpotifyClientID() string {
+	return strings.TrimSpace(c.Auth.ClientID)
 }
 
 func getDefaultAppConfig() AppConfig {
@@ -86,6 +95,20 @@ func LoadConfig() (AppConfig, error) {
 		return AppConfig{}, err
 	}
 	return config, nil
+}
+
+func ValidateStartupConfig() error {
+	if configLoadErr != nil {
+		return fmt.Errorf("failed to load config: %w", configLoadErr)
+	}
+	return validateStartupConfig(config)
+}
+
+func validateStartupConfig(cfg AppConfig) error {
+	if cfg.SpotifyClientID() == "" {
+		return fmt.Errorf("missing required config value `auth.client_id`; see %s", SpotifyClientIDHelpURL)
+	}
+	return nil
 }
 
 func getConfigDir() string {

--- a/core/utils/app_config_test.go
+++ b/core/utils/app_config_test.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAppConfigSpotifyClientIDPrefersAuthClientID(t *testing.T) {
+	cfg := AppConfig{}
+	cfg.Auth.ClientID = "auth-client-id"
+
+	if got := cfg.SpotifyClientID(); got != "auth-client-id" {
+		t.Fatalf("SpotifyClientID() = %q, want %q", got, "auth-client-id")
+	}
+}
+
+func TestAppConfigSpotifyClientIDTrimsWhitespace(t *testing.T) {
+	cfg := AppConfig{}
+	cfg.Auth.ClientID = " auth-client-id "
+
+	if got := cfg.SpotifyClientID(); got != "auth-client-id" {
+		t.Fatalf("SpotifyClientID() = %q, want %q", got, "auth-client-id")
+	}
+}
+
+func TestValidateStartupConfigRequiresSpotifyClientID(t *testing.T) {
+	err := validateStartupConfig(AppConfig{})
+	if err == nil {
+		t.Fatal("validateStartupConfig() returned nil, want error")
+	}
+	want := "missing required config value `auth.client_id`"
+	if got := err.Error(); !strings.HasPrefix(got, want) {
+		t.Fatalf("validateStartupConfig() error = %q, want prefix %q", got, want)
+	}
+}
+
+func TestValidateStartupConfigAcceptsConfiguredSpotifyClientID(t *testing.T) {
+	cfg := AppConfig{}
+	cfg.Auth.ClientID = "configured-client-id"
+
+	if err := validateStartupConfig(cfg); err != nil {
+		t.Fatalf("validateStartupConfig() error = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Remove the bundled Spotify client ID and require `auth.client_id` to be set in config or via `AUTH_CLIENT_ID`.
- Validate startup config before launching the app and fail fast with a clear error if the client ID is missing.
- Update auth setup to use the configured client ID for both the auth client and generated auth URL.
- Add tests for client ID loading, trimming, and startup validation, plus README guidance for setup.

## Testing
- `go test ./core/utils`
- Not run: full repository test suite
- Not run: manual startup validation with a configured `auth.client_id`