### PR TITLE
Migrate UI colors to ANSI16 palette

### DIFF
--- a/ui/v1/app/view.go
+++ b/ui/v1/app/view.go
@@ -8,11 +8,11 @@ import (
 )
 
 func (m *Model) View() tea.View {
-	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.BrightBlack)
 	if m.fatalErr != nil {
-		title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("9")).Render("Error")
+		title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.BrightRed).Render("Error")
 		message := lipgloss.NewStyle().MarginTop(1).Align(lipgloss.Center).Render(fmt.Sprintf("%v", m.fatalErr))
-		hint := lipgloss.NewStyle().MarginTop(1).Foreground(lipgloss.Color("8")).Render("Exiting...")
+		hint := lipgloss.NewStyle().MarginTop(1).Foreground(lipgloss.BrightBlack).Render("Exiting...")
 		content := lipgloss.JoinVertical(lipgloss.Center, title, message, hint)
 		view := lipgloss.NewStyle().Width(m.width).Height(m.height).Align(lipgloss.Center, lipgloss.Center).Render(content)
 		return tea.NewView(view)

--- a/ui/v1/auth/view.go
+++ b/ui/v1/auth/view.go
@@ -12,14 +12,14 @@ func (m *Model) View() tea.View {
 		return tea.NewView(fmt.Sprintf("Authentication failed: %v\nExiting...", m.err))
 	}
 	if m.auth.AuthServer.Started.Load() {
-		head := lipgloss.NewStyle().Width(m.width).Foreground(lipgloss.Color("11")).MarginBottom(1).Render("Authenticating with Spotify")
+		head := lipgloss.NewStyle().Width(m.width).Foreground(lipgloss.BrightYellow).MarginBottom(1).Render("Authenticating with Spotify")
 		msg := lipgloss.NewStyle().Width(m.width).MarginBottom(1).Render("Please open this link in your browser")
-		styledURL := lipgloss.NewStyle().Width(m.width).Foreground(lipgloss.Color("12")).Render(m.auth.GetAuthURL())
+		styledURL := lipgloss.NewStyle().Width(m.width).Foreground(lipgloss.BrightBlue).Render(m.auth.GetAuthURL())
 		hintText := "press c to copy"
-		hintColor := lipgloss.Color("8")
+		hintColor := lipgloss.BrightBlack
 		if m.copied {
 			hintText = "✓ copied to clipboard"
-			hintColor = lipgloss.Color("10")
+			hintColor = lipgloss.BrightGreen
 		}
 		hint := lipgloss.NewStyle().Foreground(hintColor).MarginTop(3).Render(hintText)
 		return tea.NewView(lipgloss.JoinVertical(lipgloss.Left, head, msg, styledURL, hint))

--- a/ui/v1/displayscreen/model.go
+++ b/ui/v1/displayscreen/model.go
@@ -26,12 +26,12 @@ func NewModel() Model {
 		styles: styles{
 			panel: lipgloss.NewStyle().
 				BorderStyle(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("30")).
-				Foreground(lipgloss.Color("229")),
-			primary: lipgloss.NewStyle().Foreground(lipgloss.Color("229")).Bold(true),
-			accent:  lipgloss.NewStyle().Foreground(lipgloss.Color("50")),
-			muted:   lipgloss.NewStyle().Foreground(lipgloss.Color("151")),
-			marquee: lipgloss.NewStyle().Foreground(lipgloss.Color("195")).Bold(true),
+				BorderForeground(lipgloss.Cyan).
+				Foreground(lipgloss.White),
+			primary: lipgloss.NewStyle().Foreground(lipgloss.BrightYellow).Bold(true),
+			accent:  lipgloss.NewStyle().Foreground(lipgloss.BrightCyan),
+			muted:   lipgloss.NewStyle().Foreground(lipgloss.White),
+			marquee: lipgloss.NewStyle().Foreground(lipgloss.BrightCyan).Bold(true),
 		},
 	}
 }

--- a/ui/v1/medialist/model.go
+++ b/ui/v1/medialist/model.go
@@ -40,17 +40,17 @@ type Model struct {
 
 func NewModel(kind common.ListKind) Model {
 	delegate := list.NewDefaultDelegate()
-	delegate.Styles.NormalTitle = delegate.Styles.NormalTitle.Foreground(lipgloss.Color("252")).PaddingLeft(1)
-	delegate.Styles.NormalDesc = delegate.Styles.NormalDesc.Foreground(lipgloss.Color("245")).PaddingLeft(1)
-	delegate.Styles.SelectedTitle = delegate.Styles.SelectedTitle.Foreground(lipgloss.Color("14")).Bold(true).BorderLeft(false).PaddingLeft(1)
-	delegate.Styles.SelectedDesc = delegate.Styles.SelectedDesc.Foreground(lipgloss.Color("117")).BorderLeft(false).PaddingLeft(1)
+	delegate.Styles.NormalTitle = delegate.Styles.NormalTitle.Foreground(lipgloss.White).PaddingLeft(1)
+	delegate.Styles.NormalDesc = delegate.Styles.NormalDesc.Foreground(lipgloss.BrightBlack).PaddingLeft(1)
+	delegate.Styles.SelectedTitle = delegate.Styles.SelectedTitle.Foreground(lipgloss.BrightCyan).Bold(true).BorderLeft(false).PaddingLeft(1)
+	delegate.Styles.SelectedDesc = delegate.Styles.SelectedDesc.Foreground(lipgloss.Cyan).BorderLeft(false).PaddingLeft(1)
 	delegate.SetSpacing(1)
 
 	listModel := list.New(nil, delegate, 0, 0)
 	styles := listModel.Styles
 	styles.Title = styles.Title.MarginLeft(1)
 	styles.TitleBar = lipgloss.NewStyle().MarginBottom(1)
-	styles.NoItems = styles.NoItems.Foreground(lipgloss.Color("8"))
+	styles.NoItems = styles.NoItems.Foreground(lipgloss.BrightBlack)
 	listModel.Styles = styles
 	listModel.SetShowHelp(false)
 	listModel.SetShowStatusBar(false)

--- a/ui/v1/medialist/view.go
+++ b/ui/v1/medialist/view.go
@@ -6,10 +6,10 @@ import (
 
 func (m Model) View() string {
 	listWidth := m.width - 4
-	listHeight := m.height - 1 
+	listHeight := m.height - 1
 	footer := ""
 	if m.pager.TotalPages > 1 {
-		footer = lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render(m.pager.View())
+		footer = lipgloss.NewStyle().Foreground(lipgloss.BrightBlack).Render(m.pager.View())
 	}
 	if listHeight < 1 {
 		listHeight = 1
@@ -24,7 +24,7 @@ func (m Model) View() string {
 	}
 	layers := []*lipgloss.Layer{
 		lipgloss.NewLayer(m.list.View()).ID("list"),
-		lipgloss.NewLayer(footer).X(listWidth/2 - lipgloss.Width(footer)/2).Y(listHeight-lipgloss.Height(footer)).ID("footer"),
+		lipgloss.NewLayer(footer).X(listWidth/2 - lipgloss.Width(footer)/2).Y(listHeight - lipgloss.Height(footer)).ID("footer"),
 	}
 	composed := lipgloss.NewCompositor(layers...)
 	return composed.Render()

--- a/ui/v1/mediapanel/model.go
+++ b/ui/v1/mediapanel/model.go
@@ -73,26 +73,26 @@ func defaultStyles() styles {
 		panel:    lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()),
 		panelNav: lipgloss.NewStyle(),
 		panelNavActive: lipgloss.NewStyle().
-			Foreground(lipgloss.Color("14")).
+			Foreground(lipgloss.BrightCyan).
 			Bold(true),
 		panelNavMuted: lipgloss.NewStyle().
-			Foreground(lipgloss.Color("8")),
+			Foreground(lipgloss.BrightBlack),
 		searchLine:   lipgloss.NewStyle(),
-		searchPrompt: lipgloss.NewStyle().Foreground(lipgloss.Color("8")),
-		searchValue:  lipgloss.NewStyle().Foreground(lipgloss.Color("252")),
+		searchPrompt: lipgloss.NewStyle().Foreground(lipgloss.BrightBlack),
+		searchValue:  lipgloss.NewStyle().Foreground(lipgloss.White),
 		infoStrip: lipgloss.NewStyle().
 			BorderStyle(lipgloss.NormalBorder()).
 			BorderTop(true).
 			BorderLeft(false).
 			BorderRight(false).
 			BorderBottom(false).
-			BorderForeground(lipgloss.Color("8")).
+			BorderForeground(lipgloss.BrightBlack).
 			Padding(0, 1),
 		infoLabel: lipgloss.NewStyle().
-			Foreground(lipgloss.Color("8")).
+			Foreground(lipgloss.BrightBlack).
 			Bold(true),
 		infoValue: lipgloss.NewStyle().
-			Foreground(lipgloss.Color("252")),
+			Foreground(lipgloss.White),
 	}
 }
 

--- a/ui/v1/player/cassette.go
+++ b/ui/v1/player/cassette.go
@@ -43,7 +43,7 @@ func (c *cassette) layers() []*lipgloss.Layer {
 	leftReelRaw := c.spokeLeft.View()
 	rightReelRaw := c.spokeRight.View()
 
-	reelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("13"))
+	reelStyle := lipgloss.NewStyle().Foreground(lipgloss.BrightMagenta)
 	leftReel := reelStyle.Render(leftReelRaw)
 	rightReel := reelStyle.Render(rightReelRaw)
 
@@ -119,21 +119,21 @@ func (c *cassette) layers() []*lipgloss.Layer {
 
 func cassetteStatusIndicator(status cassetteStatus) string {
 	if !status.Online {
-		dot := lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true).Render("●")
-		text := lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true).Render(" GETTING READY")
+		dot := lipgloss.NewStyle().Foreground(lipgloss.BrightYellow).Bold(true).Render("●")
+		text := lipgloss.NewStyle().Foreground(lipgloss.BrightYellow).Bold(true).Render(" GETTING READY")
 		return dot + text
 	}
 	if status.ShowVolume {
 		bar := volumeBar(status.Volume, status.VolumeMax, 10)
 		text := fmt.Sprintf("[%s] %d%%", bar, volumePercent(status.Volume, status.VolumeMax))
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true).Render(text)
+		return lipgloss.NewStyle().Foreground(lipgloss.BrightGreen).Bold(true).Render(text)
 	}
 	if status.Playing {
 		text := lipgloss.JoinHorizontal(lipgloss.Left, formatDuration(status.CurrentMs), "/", formatDuration(status.DurationMs))
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true).Render(text)
+		return lipgloss.NewStyle().Foreground(lipgloss.BrightGreen).Bold(true).Render(text)
 	}
-	dot := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true).Render("●")
-	text := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true).Render(" READY")
+	dot := lipgloss.NewStyle().Foreground(lipgloss.BrightGreen).Bold(true).Render("●")
+	text := lipgloss.NewStyle().Foreground(lipgloss.BrightGreen).Bold(true).Render(" READY")
 	return dot + text
 }
 
@@ -181,17 +181,17 @@ func cassetteShell(innerW, innerH int) string {
 		lines = append(lines, "│"+fill+"│")
 	}
 	lines = append(lines, "╰─"+strings.Repeat("═", innerW-2)+"─╯")
-	return lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render(strings.Join(lines, "\n"))
+	return lipgloss.NewStyle().Foreground(lipgloss.BrightCyan).Render(strings.Join(lines, "\n"))
 }
 
 func cassetteLabel() string {
 	labelStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("13")).
-		Background(lipgloss.Color("0")).
+		Foreground(lipgloss.BrightMagenta).
+		Background(lipgloss.Black).
 		Bold(true)
 	accentStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("11")).
-		Background(lipgloss.Color("0")).
+		Foreground(lipgloss.BrightYellow).
+		Background(lipgloss.Black).
 		Bold(true)
 	return accentStyle.Render(" ★ ") +
 		labelStyle.Render(" LAZYSPOTIFY ") +
@@ -201,7 +201,7 @@ func cassetteLabel() string {
 
 func cassetteSubtitle() string {
 	return lipgloss.NewStyle().
-		Foreground(lipgloss.Color("7")).
+		Foreground(lipgloss.White).
 		Faint(true).
 		Render("TYPE I  │  STEREO  │  SIDE A")
 }
@@ -212,7 +212,7 @@ func cassetteWindowTrim() string {
 		"║ ◎ ║ ╌╌╌╌╌╌ ║ ◎ ║",
 		"╚═══╝        ╚═══╝",
 	}
-	return lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Render(strings.Join(lines, "\n"))
+	return lipgloss.NewStyle().Foreground(lipgloss.BrightCyan).Render(strings.Join(lines, "\n"))
 }
 
 func cassetteTapeWindow() string {
@@ -222,17 +222,17 @@ func cassetteTapeWindow() string {
 		"│▓░      ░▓│",
 		"╰──────────╯",
 	}
-	return lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Render(strings.Join(lines, "\n"))
+	return lipgloss.NewStyle().Foreground(lipgloss.Yellow).Render(strings.Join(lines, "\n"))
 }
 
 func cassetteWriteProtect() string {
-	badgeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Bold(true)
-	bracketStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	badgeStyle := lipgloss.NewStyle().Foreground(lipgloss.BrightYellow).Bold(true)
+	bracketStyle := lipgloss.NewStyle().Foreground(lipgloss.BrightBlack)
 	return bracketStyle.Render("⟦ ") + badgeStyle.Render("CHROME") + bracketStyle.Render(" · IEC II ⟧")
 }
 
 func cassetteScrew() string {
-	return lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Render("x")
+	return lipgloss.NewStyle().Foreground(lipgloss.BrightWhite).Render("x")
 }
 
 func maxInt(values ...int) int {

--- a/ui/v1/player/model.go
+++ b/ui/v1/player/model.go
@@ -66,7 +66,7 @@ func buildButtons(specs []buttonSpec) []button {
 	return commonButtons(specs, func(spec buttonSpec) button {
 		return button{
 			kind:  spec.kind,
-			style: lipgloss.NewStyle().Foreground(lipgloss.Color("14")),
+			style: lipgloss.NewStyle().Foreground(lipgloss.BrightCyan),
 			icon:  spec.icon,
 		}
 	})

--- a/ui/v1/player/view.go
+++ b/ui/v1/player/view.go
@@ -73,11 +73,11 @@ func (b *button) View() string {
 		btnH = 3
 	)
 
-	shellColor := lipgloss.Color("8")
+	shellColor := lipgloss.BrightBlack
 	iconStyle := b.style
 	if b.pressed {
-		shellColor = lipgloss.Color("10")
-		iconStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)
+		shellColor = lipgloss.BrightGreen
+		iconStyle = lipgloss.NewStyle().Foreground(lipgloss.BrightWhite).Bold(true)
 	}
 	shell := lipgloss.NewStyle().Foreground(shellColor).Render(buttonShell(btnW, btnH, b.pressed))
 	iconW := lipgloss.Width(b.icon)


### PR DESCRIPTION
## Summary
- Replaced legacy numeric Lip Gloss color codes with ANSI16 named colors across the v1 UI.
- Updated app, auth, list, panel, and player surfaces to use brighter, more consistent foregrounds and borders.
- Kept layout and behavior unchanged; this is a visual palette migration only.

## Testing
- Not run: no automated tests were executed.
- Not run: no manual UI verification was performed in this workspace.
- Not run: no screenshot or terminal rendering comparison was captured.