### PR TITLE
fix(volume): use librespot 0-65535 scale for fallback maxVolume

### DIFF
--- a/ui/v1/app/model.go
+++ b/ui/v1/app/model.go
@@ -324,7 +324,7 @@ func (m *Model) markVolumeOverlay() {
 func (m *Model) previewVolume(delta int) {
 	maxVolume := m.volumeInfo.Max
 	if maxVolume <= 0 {
-		maxVolume = 100
+		maxVolume = 65535
 	}
 	m.volumeInfo.Volume = max(0, min(maxVolume, m.volumeInfo.Volume+delta))
 }
@@ -340,7 +340,7 @@ func (m *Model) advancePlayback(elapsedMs int) {
 func (m *Model) updatePlayerStatus() {
 	maxVolume := m.volumeInfo.Max
 	if maxVolume <= 0 {
-		maxVolume = 100
+		maxVolume = 65535
 	}
 	m.mediaCenter.UpdatePlayerStatus(player.Status{
 		PlayerReady: m.playerReady,
@@ -404,7 +404,7 @@ func (m *Model) changeVolume(delta int) (common.VolumeInfo, error) {
 		maxVolume = m.volumeInfo.Max
 	}
 	if maxVolume <= 0 {
-		maxVolume = 100
+		maxVolume = 65535
 	}
 
 	target := max(0, min(maxVolume, volume.Value+delta))

--- a/ui/v1/player/cassette.go
+++ b/ui/v1/player/cassette.go
@@ -149,7 +149,7 @@ func formatDuration(ms int) string {
 
 func volumePercent(volume, maxVolume int) int {
 	if maxVolume <= 0 {
-		maxVolume = 100
+		maxVolume = 65535
 	}
 	volume = max(0, min(volume, maxVolume))
 	return int(float64(volume) * 100 / float64(maxVolume))
@@ -157,7 +157,7 @@ func volumePercent(volume, maxVolume int) int {
 
 func volumeBar(volume, maxVolume, width int) string {
 	if maxVolume <= 0 {
-		maxVolume = 100
+		maxVolume = 65535
 	}
 	if width <= 0 {
 		width = 10


### PR DESCRIPTION
Closes #17.

`j` and `k` only ever set the volume to 0 or 100 because the fallback `maxVolume` is 100 while `VolumeStep` is in librespot's native 0-65535 range:

```go
// core/utils/app_config.go
cfg.Librespot.VolumeStep = 65535 / 20  // = 3276
```

When the model's `volumeInfo.Max` is still unset (no `EventTypeVolume` event has fired yet) and `GetVolume()` returns `Max <= 0`, the code falls back to `maxVolume = 100`. Then:

- `j`: `target = clamp(0, 100, current + 3276) = 100`
- `k`: `target = clamp(0, 100, current - 3276) = 0`

Match the unit by switching all six fallback branches from 100 to 65535:

- `ui/v1/app/model.go`: `previewVolume`, `updatePlayerStatus`, `changeVolume`
- `ui/v1/player/cassette.go`: `volumePercent`, `volumeBar`

The display layer (`volumePercent` / `volumeBar`) keeps working correctly because both normalize by `maxVolume` before scaling, so 65535 produces the right percent / bar fill instead of always saturating.

## Verification

```
$ go build ./...
$ go test ./...
ok  github.com/dubeyKartikay/lazyspotify/core/utils
ok  github.com/dubeyKartikay/lazyspotify/librespot
ok  github.com/dubeyKartikay/lazyspotify/ui/v1/common
ok  github.com/dubeyKartikay/lazyspotify/ui/v1/displayscreen
ok  github.com/dubeyKartikay/lazyspotify/ui/v1/medialist
ok  github.com/dubeyKartikay/lazyspotify/ui/v1/mediapanel
ok  github.com/dubeyKartikay/lazyspotify/ui/v1/player
```

This contribution was developed with AI assistance (Claude Code).