### PR TITLE
fix: q quits in search mode

### DIFF
--- a/ui/v1/common/keys.go
+++ b/ui/v1/common/keys.go
@@ -37,8 +37,8 @@ func NewAppKeyMap() AppKeyMap {
 			key.WithHelp("?", "toggle help"),
 		),
 		Quit: key.NewBinding(
-			key.WithKeys("q", "ctrl+c"),
-			key.WithHelp("q", "quit"),
+			key.WithKeys("ctrl+c"),
+			key.WithHelp("ctrl+c", "quit"),
 		),
 		CycleLibrary: key.NewBinding(
 			key.WithKeys("tab"),


### PR DESCRIPTION
## Summary

Fixes #31 

## Testing

- [x] `go test ./...`
- [ ] Manual verification completed when needed

## Checklist

- [ ] Documentation updated if behavior, config, or installation changed
- [ ] No unrelated refactors included
- [ ] Breaking changes called out explicitly

## Notes

removing the key `q` to quit. it was a bad design choice 
