### PR TITLE
Fixed volume stepping with j/k. Calculates the percentage according to the librespot volume scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The generated daemon config is written automatically under the `librespot/` subd
 | `librespot.retry-delay` | No | `100` | Retry delay in milliseconds. |
 | `librespot.max-retries` | No | `3` | Retry count for daemon calls. |
 | `librespot.seek-step-ms` | No | `5000` | Seek step size in milliseconds. |
-| `librespot.volume-step` | No | `3276` | Volume step used for volume controls. |
+| `librespot.volume-step` | No | `20` | Volume step percentage (0-100) used for volume controls. |
 | `librespot.daemon.cmd` | Sometimes | none | Required for source/manual installs unless a packaged daemon path was compiled into the binary. |
 | `librespot.daemon.log_level` | No | `ERROR` | Log level written into the generated librespot daemon config. |
 | `librespot.daemon.zeroconf_enabled` | No | `false` | Enables zeroconf in the daemon config. |

--- a/core/utils/app_config.go
+++ b/core/utils/app_config.go
@@ -81,7 +81,7 @@ func getDefaultAppConfig() AppConfig {
 	cfg.Librespot.RetryDelay = 100
 	cfg.Librespot.MaxRetries = 3
 	cfg.Librespot.SeekStepMs = 5000
-	cfg.Librespot.VolumeStep = 65535 / 20
+	cfg.Librespot.VolumeStep = 20
 	cfg.Librespot.Daemon.LogLevel = "ERROR"
 	return cfg
 }

--- a/core/utils/app_config_test.go
+++ b/core/utils/app_config_test.go
@@ -70,6 +70,14 @@ func TestGetDefaultAppConfigUsesErrorLogLevels(t *testing.T) {
 	}
 }
 
+func TestGetDefaultAppConfigVolumeStepIsPercentage(t *testing.T) {
+	cfg := getDefaultAppConfig()
+
+	if got := cfg.Librespot.VolumeStep; got != 20 {
+		t.Fatalf("getDefaultAppConfig().Librespot.VolumeStep = %d, want 20", got)
+	}
+}
+
 func TestLoadConfigCreatesConfigYMLWhenMissing(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)

--- a/ui/v1/app/model.go
+++ b/ui/v1/app/model.go
@@ -389,7 +389,7 @@ func (m *Model) previous() error {
 	return m.player.Previous(context.Background())
 }
 
-func (m *Model) changeVolume(delta int) (common.VolumeInfo, error) {
+func (m *Model) changeVolume(deltaPercent int) (common.VolumeInfo, error) {
 	if m.player == nil {
 		return common.VolumeInfo{}, fmt.Errorf("player not ready")
 	}
@@ -404,9 +404,10 @@ func (m *Model) changeVolume(delta int) (common.VolumeInfo, error) {
 		maxVolume = m.volumeInfo.Max
 	}
 	if maxVolume <= 0 {
-		maxVolume = 100
+		maxVolume = 65535
 	}
 
+	delta := maxVolume * deltaPercent / 100
 	target := max(0, min(maxVolume, volume.Value+delta))
 	if err := m.player.SetVolume(context.Background(), target, false); err != nil {
 		return common.VolumeInfo{}, err

--- a/ui/v1/app/model.go
+++ b/ui/v1/app/model.go
@@ -407,7 +407,7 @@ func (m *Model) changeVolume(deltaPercent int) (common.VolumeInfo, error) {
 		maxVolume = 65535
 	}
 
-	delta := maxVolume * deltaPercent / 100
+	delta := calcVolumeDelta(maxVolume, deltaPercent)
 	target := max(0, min(maxVolume, volume.Value+delta))
 	if err := m.player.SetVolume(context.Background(), target, false); err != nil {
 		return common.VolumeInfo{}, err
@@ -544,6 +544,10 @@ func paginationFromCursor(page, count, total, pageSize int, nextCursor string) c
 		HasNext:     hasNext,
 		NextCursor:  nextCursor,
 	}
+}
+
+func calcVolumeDelta(maxVolume, stepPercent int) int {
+	return maxVolume * stepPercent / 100
 }
 
 func ExitIfRunFails(err error) {

--- a/ui/v1/app/volume_test.go
+++ b/ui/v1/app/volume_test.go
@@ -1,0 +1,27 @@
+package app
+
+import "testing"
+
+func TestCalcVolumeDeltaScalesWithMaxVolume(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxVolume  int
+		stepPercent int
+		want       int
+	}{
+		{"20% of librespot max", 65535, 20, 13107},
+		{"20% of 100", 100, 20, 20},
+		{"negative step decrements", 65535, -20, -13107},
+		{"5% matches old hardcoded value", 65535, 5, 3276},
+		{"0% produces no change", 65535, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calcVolumeDelta(tt.maxVolume, tt.stepPercent)
+			if got != tt.want {
+				t.Fatalf("calcVolumeDelta(%d, %d) = %d, want %d", tt.maxVolume, tt.stepPercent, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Testing
- [x] go test pass
- [x] added test
- [x] Built locally and verified j/k steps volume by 20 when it is not specified in config.

### Checklist

- [x]  Documentation updated if behavior, config, or installation changed
- [x] No unrelated refactors included
- [x] Breaking changes called out explicitly