### PR TITLE
temp fix: strip emojis from entity title/desc

### DIFF
--- a/ui/v1/common/types.go
+++ b/ui/v1/common/types.go
@@ -1,6 +1,7 @@
 package common
 
 import "strings"
+import "unicode"
 
 type Entity struct {
 	Name string
@@ -185,4 +186,22 @@ func MapSlice[T any, U any](items []T, mapFn func(T) U) []U {
 		mapped = append(mapped, mapFn(item))
 	}
 	return mapped
+}
+
+func StripEmojis(s string) string {
+	return strings.Map(func(r rune) rune {
+		if IsEmoji(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+func IsEmoji(r rune) bool {
+	return unicode.Is(unicode.So, r) ||
+		unicode.Is(unicode.Sk, r) ||
+		(r >= 0x1F000 && r <= 0x1FAFF) || // the big emoji block (😀🎉🐶 etc.)
+		(r >= 0x2600 && r <= 0x27BF) || // misc symbols & dingbats (☀️⚡ etc.)
+		r == 0x200D || // zero-width joiner (used in family emoji etc.)
+		(r >= 0xFE00 && r <= 0xFE0F)
 }

--- a/ui/v1/medialist/update.go
+++ b/ui/v1/medialist/update.go
@@ -2,6 +2,7 @@ package medialist
 
 import (
 	"fmt"
+	"strings"
 
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
@@ -131,7 +132,12 @@ type listItem struct {
 }
 
 func (i listItem) Title() string {
-	return common.StripEmojis(i.entity.Name)
+	title := common.StripEmojis(i.entity.Name)
+	// handle edge case where entity title is only emojis
+	if strings.TrimSpace(title) == "" {
+		return "(untitled)"
+	}
+	return title
 }
 
 func (i listItem) Description() string {

--- a/ui/v1/medialist/update.go
+++ b/ui/v1/medialist/update.go
@@ -131,13 +131,13 @@ type listItem struct {
 }
 
 func (i listItem) Title() string {
-	return i.entity.Name
+	return common.StripEmojis(i.entity.Name)
 }
 
 func (i listItem) Description() string {
-	return i.entity.Desc
+	return common.StripEmojis(i.entity.Desc)
 }
 
 func (i listItem) FilterValue() string {
-	return fmt.Sprintf("%s %s", i.entity.Name, i.entity.Desc)
+	return fmt.Sprintf("%s %s", common.StripEmojis(i.entity.Name), common.StripEmojis(i.entity.Desc))
 }


### PR DESCRIPTION
## Summary

this PR temporarily introduces a fix for #51 until a complete and proper implementation of emoji rendering can be done. this PR strips all emojis out of entity titles and descriptions to prevent interference of TUI rendering.
titles with only emojis are given an `(untitled)` placeholder, descriptions are left blank (expected use case).

## Testing

- [x] `go test ./...`
- [x] Manual verification completed when needed


## Checklist

- [x] Documentation updated if behavior, config, or installation changed
- N/A
- [x] No unrelated refactors included

## Notes

packages added:
`./ui/v1/common/types.go`:
- added `unicode` package for unicode emoji detection

`./ui/v1/medialist/update.go`:
- added `strings` package for parsing entity titles

i'm relatively new to open source contribution so let me know if i've done something glaringly wrong. thanks!