### PR TITLE
docs: add Nix install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ brew install lazyspotify
 yay -S lazyspotify-bin
 ```
 
+### Nix
+
+Available in [Nixpkgs](https://search.nixos.org/packages?channel=unstable&query=lazyspotify#show=lazyspotify).
+
+```bash
+nix run nixpkgs#lazyspotify
+```
+
 ### GitHub Releases
 
 Download the latest package from [GitHub Releases](https://github.com/dubeyKartikay/lazyspotify/releases).


### PR DESCRIPTION
## Summary

This PR updates the README to include the Nixpkgs installation method. 

lazyspotify has recently been merged into the official nixpkgs repository. Adding this to the README allows Nix users to easily discover how to install and run the application natively.

This supersedes the need for a custom local flake as previously proposed in #38.

## Testing

- [ ] `go test ./...`
- [x] Manual verification completed when needed

## Checklist

- [x] Documentation updated if behavior, config, or installation changed
- [x] No unrelated refactors included
- [x] Breaking changes called out explicitly
